### PR TITLE
Mention Svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This approach is doable, but lacks DX. Writing React.js components is simpler th
 
 What if we could transpile React.js components to native DOM operations at build-time? This would eliminate the need for the react library at cost of a bit larger component code.
 
+[Svelte](https://svelte.technology/) has proven that this type of framework-eliminating transpilation can work very well.
+
 ## Introducing Rawact
 
 Rawact (raw-react) is a babel plugin which does this transformation.


### PR DESCRIPTION
I saw the [tweet](https://mobile.twitter.com/wSokra/status/1060520070827425792) that introduced this:

> Ideas from Svelte applied to React.js...
> 
> Compile React Components to native DOM operations to eliminate the react and react-dom runtime.
> 
> Smaller and faster in many cases.
> 
> Here is a proof of concept with explanations:
> https://github.com/sokra/rawact

I thought it was cool so I sent the repo to a friend. We started talking about it, but when I brought up Svelte he was immediately confused. He hadn't heard of Svelte and the repository doesn't mention or link to it anywhere (and I'd only sent him the repository, not the tweet).

I thought it would be nice to link to Svelte in the README since rawact was at least partly inspired by Svelte and Svelte is a tool that people (not just @Rich-Harris) are using in production, which is currently not recommended for rawact:
https://github.com/sokra/rawact/blob/422f35d61fec593c8160120104728debb39b0794/README.md#L25