### PR TITLE
Allow tests to run after cloning repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "sideEffects": false,
   "scripts": {
     "prepublishOnly": "rimraf lib && babel src -d lib",
-    "start": "rimraf lib && babel src -d lib -w",
-    "test": "jest"
+    "start": "npm run prepublishOnly -- -w",
+    "test": "npm run prepublishOnly && jest"
   },
   "files": [
     "lib"


### PR DESCRIPTION
After cloning, I started with `npm test` and it failed with a unclear error, because lib wasn't built.

I thought about abstracting the npm build task, but I see you use yarn.. not sure what the normal aproach is here.