### PR TITLE
Give a `this` to render()

### DIFF
--- a/src/runtime/hooks.js
+++ b/src/runtime/hooks.js
@@ -53,7 +53,7 @@ export default (component, props) => {
 		currentRerender = rerender;
 		currentComponent = context;
 
-		const instructions = render(props, component);
+		const instructions = render.call(currentComponent, props, component);
 
 		if (context.i === instructions) return context.n;
 


### PR DESCRIPTION
This was failing on my end, because the render function of my component used `this`, and it was undefined.